### PR TITLE
Get single scan dev

### DIFF
--- a/classes/DAQBox.m
+++ b/classes/DAQBox.m
@@ -627,7 +627,7 @@ classdef DAQBox < handle
                 % temperature and current units
                 [tempReading_Ref, tempReading_Samp,...
                 currentReading_Ref, currentReading_Samp]...
-                = extractDaqData(data);
+                = obj.extractDaqData(data);
                 
             else
                 % Simulate the input values if a DAQ Box is not connected
@@ -664,7 +664,7 @@ classdef DAQBox < handle
                 % temperature and current units
                 [tempReading_Ref, tempReading_Samp,...
                 currentReading_Ref, currentReading_Samp]...
-                = extractDaqData(data);
+                = obj.extractDaqData(data);
                 
             else
                 % Simulate the input values if a DAQ Box is not connected

--- a/classes/StageController.m
+++ b/classes/StageController.m
@@ -506,7 +506,7 @@ classdef StageController < handle
                     % Take an initial reading of the temperatures and power
                     [latestSerialDate, latestTemp_Ref, latestTemp_Samp,...
                         latestCurrent_Ref, latestCurrent_Samp]...
-                        = obj.daqBox.getBackgroundData('single');
+                        = obj.daqBox.getSingleScanData();
                     
                     % Initialize the TargetTemp to zero
                     obj.TargetTemp = 0;


### PR DESCRIPTION
Moved the call of `inputSingleScan()` to a separate method to avoid the use of `if (~isa(event, 'char')` which had been causing problems.
Since the program now uses background data acquisition, there is no reason to have both the single scan and the continuous measurement in the same method of the DAQBox class.